### PR TITLE
Switch xdg to pyxdg module

### DIFF
--- a/firefly_cli/configs_manager.py
+++ b/firefly_cli/configs_manager.py
@@ -1,8 +1,9 @@
 from pathlib import Path
 import configparser
-from xdg import xdg_config_home
+from xdg.BaseDirectory import xdg_config_home
 
-config_file_path = xdg_config_home().joinpath('firefly-cli', 'firefly-cli.ini')
+config_file_path = Path(xdg_config_home).joinpath('firefly-cli', 'firefly-cli.ini')
+# config_file_path = xdg_config_home().joinpath('firefly-cli', 'firefly-cli.ini')
 
 # Create dir if not exists
 config_file_path.parents[0].mkdir(parents=True, exist_ok=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ requests==2.25.1
 six==1.15.0
 tabulate==0.8.7
 urllib3==1.26.2
-xdg==5.0.1
+pyxdg==0.26

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
         'pandas==1.1.4',
         'requests==2.25.1',
         'tabulate==0.8.7',
-        'xdg==5.0.1',
+        'pyxdg==0.26',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
The pyxdg module is maintained by freedesktop upstream and thus is the more authoritative one. Even though it is a little clumsier to use than the xdg module that was being used earlier.

It would be great if you could accept this change. If not, no problems, I understand. I'll just have to maintain the patch on top to allow this to work on archlinux