### PR TITLE
Fix accounts command type parameter

### DIFF
--- a/firefly_cli/cli.py
+++ b/firefly_cli/cli.py
@@ -118,7 +118,7 @@ limitations under the License.
 
     @cmd2.with_argparser(Parser.accounts())
     def do_accounts(self, parser):
-        accounts = self.api.get_accounts(limit=parser.limit)
+        accounts = self.api.get_accounts(limit=parser.limit, account_type=parser.type)
         if parser.json:
             self.poutput(json.dumps(accounts, sort_keys=True, indent=4))
         else:


### PR DESCRIPTION
It may also be desirable to change the default value of --type to "asset" to keep the current default behavior of the accounts command